### PR TITLE
sirv を kill できていなかったので sh を経由しないように修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,23 @@
 # playwright-test-sample
 This repository is for Playwight validation
 
+## Install dependencies:
+
+```shell
+npm install
+```
+
 ## Run Test
 
-```
-$(npm bin)/playwright test src/static-site1-test.spec.ts
+Run test (headless execution):
+
+```shell
+npx playwright test src/static-site1-test.spec.ts
 ```
 
-Use headed
-```
-$(npm bin)/playwright test src/static-site1-test.spec.ts --headed
+Run test with browser window:
+
+```shell
+npx playwright test src/static-site1-test.spec.ts --headed
 ```
 

--- a/src/StaticHttpServer.ts
+++ b/src/StaticHttpServer.ts
@@ -28,11 +28,11 @@ export class StaticHttpServer {
   start(): void {
     // https://github.com/lukeed/sirv/tree/master/packages/sirv-cli
     const proc = spawn(
-      '$(npm bin)/sirv',
-      [join(__dirname, 'static-site1'), '--port', this.port.toString()],
+      'npx',
+      ['sirv', join(__dirname, 'static-site1'), '--port', this.port.toString()],
       {
         detached: false,
-        shell: true,
+        shell: false,
         stdio: ['ignore', 'pipe', 'pipe'],
       }
     );
@@ -42,10 +42,11 @@ export class StaticHttpServer {
     this.handleReadable('stderr', proc.stderr);
 
     this.serverProcess = proc;
+    log(`Started sirv with pid=${proc.pid}\n`);
 
     // https://github.com/jeffbski/wait-on
     execSync(
-      `$(npm bin)/wait-on http://localhost:${this.port} --delay 1000 --httpTimeout 30000`
+      `npx wait-on http://localhost:${this.port} --delay 1000 --httpTimeout 30000`
     );
   }
 
@@ -95,7 +96,7 @@ export class StaticHttpServer {
   }
 
   killProcess(p: ChildProcess): void {
-    log('serverProcess is being killed\n');
+    log(`serverProcess (pid=${p.pid}) is being killed\n`);
     if (p.kill('SIGTERM')) {
       log('serverProcess was killed with SIGTERM\n');
     } else if (p.kill()) {


### PR DESCRIPTION
`npx playwright test src/static-site1-test.spec.ts` でテストを実行したあと、
sirv のプロセスが残ることに気付きました。

```
yamada@WEZEN% npx playwright test src/static-site1-test.spec.ts

Running 8 tests using 1 worker

(..snip...)

  8 passed (7s)
yamada@WEZEN% ps auxw | grep sirv
yamada     83223  0.2  0.2 615012 40600 pts/1    Sl   20:44   0:00 node /home/yamada/go/src/github.com/TakeruUshio/playwright-test-sample/node_modules/.bin/sirv /home/yamada/go/src/github.com/TakeruUshio/playwright-test-sample/src/static-site1 --port 5000
yamada     83640  0.0  0.0   4544  2148 pts/1    S+   20:46   0:00 grep -i --color=auto sirv
```

このため、続けてもう一度テストを実行するとポート5000が既に使われているので失敗します。

原因を調べてみると

`spawn(...)` で sh を経由して sirv を起動しているので、テスト終了時に kill しているのは sh のプロセスだけで、
sh の子プロセスである sirv (node) は kill できていませんでした。

`spawn(...)` で sh を経由しないように、そして `$(npm bin)` のかわりに npx を使うように変更しました。
